### PR TITLE
[CPU] Avoid copy result and force allocation

### DIFF
--- a/vllm/executor/openvino_executor.py
+++ b/vllm/executor/openvino_executor.py
@@ -119,6 +119,9 @@ class OpenVINOCacheEngine:
         for _ in range(self.num_layers):
             key_blocks = ov.Tensor(self.cache_dtype, key_block_shape)
             value_blocks = ov.Tensor(self.cache_dtype, value_block_shape)
+            # force allocation
+            key_blocks.data[:] = 0
+            value_blocks.data[:] = 0
             cpu_cache.append((key_blocks, value_blocks))
         return cpu_cache
 

--- a/vllm/model_executor/openvino_model_loader.py
+++ b/vllm/model_executor/openvino_model_loader.py
@@ -51,8 +51,9 @@ def ov_wrapper(self, *args, **kwargs) -> torch.Tensor:
     else:
         inputs.append(np.array(0, dtype=np.int32))   # for optimum-based models this parameter can be used even on the first iteration
 
-    outputs = self._ov_request.infer(inputs, share_inputs=True, share_outputs=False)
-    return torch.from_numpy(outputs[0])
+    self._ov_request.start_async(inputs, share_inputs=True)
+    self._ov_request.wait()
+    return torch.from_numpy(self._ov_request.get_tensor("logits").data)
 
 
 def patch_stateful_model(


### PR DESCRIPTION
- avoid copy result, using the approach the [genai used](https://github.com/huggingface/optimum-intel/blob/77503fcf2e9d29f1b7da4047967e7fa1e2db9e35/optimum/intel/openvino/modeling_decoder.py#L465-L467), for the 1024 of input len, first inference can reduce from ~830 ms to ~790 ms.
- force kvcache allocation ahead to avoid the first few prompts cost is longer than expected, it can save about 20~30ms for the first inference cost of problem sentences.