### PR TITLE
Extended vLLM transform for optimum-intel based models + Utilities

### DIFF
--- a/vllm/model_executor/openvino_model_loader.py
+++ b/vllm/model_executor/openvino_model_loader.py
@@ -168,7 +168,7 @@ def patch_stateful_model(
                 real_q = mapping[q]
 
                 # takes option that has 4D instead of fine-grained Reshape analysis
-                # it is avoids complication in pattern, but we don't really have many options
+                # it avoids complication in the pattern, but we don't really have many options
                 def take_4d(option1, option2, option3):
                     if option1 in mapping and mapping[option1].get_partial_shape().rank.get_length() == 4:
                         return mapping[option1]

--- a/vllm/model_executor/openvino_model_loader.py
+++ b/vllm/model_executor/openvino_model_loader.py
@@ -2,7 +2,7 @@
 from functools import partial
 from typing import Optional
 from pathlib import Path
-import math
+import os
 import torch
 import numpy as np
 from huggingface_hub import HfApi
@@ -51,7 +51,7 @@ def ov_wrapper(self, *args, **kwargs) -> torch.Tensor:
         inputs.append(input_metadata.context_lens)
         inputs.append(input_metadata.block_tables)
     else:
-        inputs.append(np.array(0, dtype=np.int32))   # for optimum-based models this parameter can be used even on the first iteration
+        inputs.append(np.array(kwargs['input_ids'].shape[1], dtype=np.int64))   # for optimum-based models this parameter can be used even on the first iteration
 
     self._ov_request.start_async(inputs, share_inputs=True)
     self._ov_request.wait()
@@ -78,16 +78,27 @@ def patch_stateful_model(
     ]
     for parameter in model_remaining_params:
         parameter.get_output_tensor(0).set_names({parameter.get_friendly_name()})
-    paged_attention_remaining_args = [
-        opset13.constant(np.array([], np.float32)),  # alibi_slopes
-        opset13.constant(np.array(0, np.int32)),  # sliding_window
-    ]
+    sliding_window = opset13.constant(np.array(0, np.int32))  # sliding_window
+
+    current_seq_len = opset13.gather(opset13.shape_of(model.input('input_ids')), opset13.constant(1), opset13.constant(0))
+    current_seq_len.set_friendly_name('my_current_seq_len')
+    prev_max_seq_len = max_context_len - current_seq_len
+
+    def has_parameter(model, name):
+        return name in sum([list(t.get_names()) for t in model.inputs], [])
 
     kv_parameters = []
-    assignes_to_remove = []
+    assignes_to_remove = []  # not really used
     parameters_to_remove = []
-    results_to_remove = []
-    position_ids_parameter = []
+    results_to_remove = []  # used, but cannot really track all Results in stateless model
+    if not has_parameter(model, 'position_ids'):
+        position_ids = opset13.parameter(shape=[-1, -1], dtype=np.int64, name="position_ids")
+        position_ids.get_output_tensor(0).set_names({position_ids.get_friendly_name()})
+        model.add_parameters([position_ids])
+        print('CREATED A NEW position_ids PARAMETER')
+    position_ids = model.input('position_ids')
+
+    kv_transpose_order = opset13.constant([0, 2, 1, 3])
 
     class StateManagementPattern(MatcherPass):
         def __init__(self):
@@ -97,8 +108,11 @@ def patch_stateful_model(
             k_past_var = WrapType("opset13.ReadValue", AnyInput())
             k_past_par = WrapType("opset13.Parameter")
             k_past = Or([WrapType("opset13.Gather", [k_past_var, AnyInput(), AnyInput()]), k_past_par])
+            k_past = Or([k_past, WrapType("opset13.Transpose", [k_past, AnyInput()])])  # Transpose is used when kv-cache is stored in a not usual layout, example: bloom
             k_current = AnyInput()
-            k_concat = WrapType("opset13.Concat", [k_past, k_current])
+            k_current2 = AnyInput()
+            k_current_reshaped = WrapType("opset13.Reshape", [k_current2, AnyInput()])
+            k_concat = WrapType("opset13.Concat", [k_past, Or([k_current_reshaped, k_current])])
 
             def kv_shaping(kv_concat):
                 interim = WrapType("opset13.StridedSlice", [kv_concat, *[AnyInput() for _ in range(3)]])
@@ -113,15 +127,38 @@ def patch_stateful_model(
             v_past_var = WrapType("opset13.ReadValue", AnyInput())
             v_past_par = WrapType("opset13.Parameter")
             v_past = Or([WrapType("opset13.Gather", [v_past_var, AnyInput(), AnyInput()]), v_past_par])
+            v_past = Or([v_past, WrapType("opset13.Transpose", [v_past, AnyInput()])])
             v_current = AnyInput()
-            v_concat = WrapType("opset13.Concat", [v_past, v_current])
+            v_current2 = AnyInput()
+            v_current_reshaped = WrapType("opset13.Reshape", [v_current2, AnyInput()])
+            v_concat = WrapType("opset13.Concat", [v_past, Or([v_current_reshaped, v_current])])
+
+            k_shaped = kv_shaping(k_concat)
+            v_shaped = kv_shaping(v_concat)
+
+            k_simply_shaped = WrapType("opset13.Reshape", [k_concat, AnyInput()])
+            v_simply_shaped = WrapType("opset13.Reshape", [v_concat, AnyInput()])
+
+            k_order = AnyInput()
+            v_order = AnyInput()
+
+            # KV-path may already have Transposes that will be rewritten based on PA KV inputs required layout
+            k_shaped_transposed = WrapType("opset13.Transpose", [Or([k_concat, k_shaped]), k_order])
+            v_shaped_transposed = WrapType("opset13.Transpose", [Or([v_concat, v_shaped]), v_order])
+
+            # Optional pattern to capture alibi slopes (based on pattern from bloom)
+            alibi = AnyInput()
+            sdpa_mask = WrapType("opset13.Multiply", [AnyInput(), alibi])  # apply input position_ids
+            sdpa_mask = WrapType("opset13.Reshape", [sdpa_mask, AnyInput()])
+            sdpa_mask = WrapType("opset13.Reshape", [sdpa_mask, AnyInput()])
+            sdpa_mask = WrapType("opset13.Select", [AnyInput(), AnyInput(), sdpa_mask])
 
             q = AnyInput()
             sdpa = WrapType("opset13.ScaledDotProductAttention", [
                 q,
-                Or([k_concat, kv_shaping(k_concat)]),
-                Or([v_concat, kv_shaping(v_concat)]),
-                AnyInput()
+                Or([k_concat, k_shaped, k_shaped_transposed, k_simply_shaped]),
+                Or([v_concat, v_shaped, v_shaped_transposed, v_simply_shaped]),
+                Or([sdpa_mask, AnyInput()])
             ])
 
             def callback(m: Matcher) -> bool:
@@ -129,23 +166,53 @@ def patch_stateful_model(
                 mapping = m.get_pattern_value_map()
                 assert sdpa in mapping
                 real_q = mapping[q]
-                real_k = mapping[k_current]
-                real_v = mapping[v_current]
-                hidden_shape = real_q.get_partial_shape()
-                hidden_dim = hidden_shape[hidden_shape.rank.get_length() - 1].get_length()  # TODO: What if it is a dynamic? Need to insert a ShapeOf sub-graph instead
+
+                # takes option that has 4D instead of fine-grained Reshape analysis
+                # it is avoids complication in pattern, but we don't really have many options
+                def take_4d(option1, option2, option3):
+                    if option1 in mapping and mapping[option1].get_partial_shape().rank.get_length() == 4:
+                        return mapping[option1]
+                    elif mapping[option2].get_partial_shape().rank.get_length() == 4:
+                        return mapping[option2]
+                    else:
+                        return mapping[option3]
+
+                real_k = take_4d(k_current, k_current2, k_current_reshaped)
+                real_v = take_4d(v_current, v_current2, v_current_reshaped)
                 k_parameter = opset13.parameter(shape=[-1, -1, -1, -1, -1], dtype=kv_cache_dtype)
                 v_parameter = opset13.parameter(shape=[-1, -1, -1, -1], dtype=kv_cache_dtype)
                 kv_parameters.append(k_parameter)
                 kv_parameters.append(v_parameter)
-                # TODO: The rank 4 is used in the following code, but it is not guaranteed for all models, adopt to other ranks.
-                q_transpose = opset13.transpose(real_q, opset13.constant([0, 2, 1, 3]))
+                q_transpose = opset13.transpose(real_q, kv_transpose_order)
                 q_reshape = opset13.reshape(q_transpose, opset13.constant([0, 0, -1]), True)
-                k_transpose = opset13.transpose(real_k, opset13.constant([0, 2, 1, 3]))
+
+                k_tranpose_order = kv_transpose_order
+                if k_order in mapping:  # reapply transpose found in the graph by manipulating of indices of our Transpose
+                    k_tranpose_order = opset13.gather(mapping[k_order], kv_transpose_order, opset13.constant(0))
+                k_transpose = opset13.transpose(real_k, k_tranpose_order)
                 k_reshape = opset13.reshape(k_transpose, opset13.constant([0, 0, -1]), True)
-                v_transpose = opset13.transpose(real_v, opset13.constant([0, 2, 1, 3]))
+
+                v_tranpose_order = kv_transpose_order
+                if v_order in mapping:  # reapply transpose found in the graph by manipulating of indices of our Transpose
+                    v_tranpose_order = opset13.gather(mapping[v_order], kv_transpose_order, opset13.constant(0))
+                v_transpose = opset13.transpose(real_v, v_tranpose_order)
                 v_reshape = opset13.reshape(v_transpose, opset13.constant([0, 0, -1]), True)
-                # TODO: Detect whether SDPA in the model graph has scale argument set and use it instead of the computed scale below
-                scale = opset13.constant(np.array(1.0/math.sqrt(float(hidden_dim)), dtype=np.float32))
+
+                # TODO: Detect whether SDPA in the model graph has `scale` argument set and use it instead of the computed scale below
+                # Most likely `scale` will always be a constant in real inference, but dynamic dimension propagation may not always derive it as a constant
+                # That's why a sub-graph computing `scale` is built instead of just a constant node.
+                hidden_shape = opset13.shape_of(real_q)
+                hidden_dim = opset13.gather(hidden_shape, opset13.constant(-1), opset13.constant(0))
+                scale = opset13.constant(1.0, dtype=ov.Type.f32)/opset13.sqrt(opset13.convert(hidden_dim, destination_type=ov.Type.f32))
+
+                if alibi in mapping:
+                    print('alibi slopes applied')
+                    alibi_slopes = opset13.reshape(mapping[alibi], opset13.constant([-1]), special_zero=False)
+                    if alibi_slopes.get_element_type() != ov.Type.f32:
+                        alibi_slopes = opset13.convert(alibi_slopes, destination_type=ov.Type.f32)  #todo
+                else:
+                    alibi_slopes = opset13.constant(np.array([], np.float32))
+
                 paged_attention = factory.create("PagedAttentionExtension", [
                     q_reshape,
                     k_reshape,
@@ -154,11 +221,19 @@ def patch_stateful_model(
                     v_parameter,
                     *model_remaining_params,
                     scale,
-                    *paged_attention_remaining_args
+                    alibi_slopes,
+                    sliding_window
                 ])
-                pa_reshape = opset13.reshape(paged_attention, [0, 0, -1, hidden_dim], True)
-                pa_transpose = opset13.transpose(pa_reshape, opset13.constant([0, 2, 1, 3]))
+                pa_shape = opset13.concat([
+                        opset13.constant([0]),
+                        opset13.constant([0]),
+                        opset13.constant([-1]),
+                        opset13.unsqueeze(hidden_dim, opset13.constant(0))
+                    ], axis=0)
+                pa_reshape = opset13.reshape(paged_attention, pa_shape, True)
+                pa_transpose = opset13.transpose(pa_reshape, kv_transpose_order)
 
+                #TODO: Complete this part to work with stateless models as well as will stateful
                 # def add_kv_parameter(past_node):
                 #     if past_node.get_type_info().name == 'Parameter':
                 #         parameters_to_remove.append(past_node)
@@ -188,9 +263,9 @@ def patch_stateful_model(
                 print('INSERTED PageAttentionExtension')
                 return True
 
-            self.register_matcher(Matcher(sdpa, "StateAndSDPA"), callback)
+            self.register_matcher(Matcher(sdpa, "StateManagementPattern"), callback)
 
-    class MaxSequenceLengthPattern(MatcherPass):
+    class PrevSequenceLengthPattern(MatcherPass):
         def __init__(self):
             MatcherPass.__init__(self)
             self.model_changed = False
@@ -201,18 +276,46 @@ def patch_stateful_model(
             seq = WrapType("opset13.Gather", [kv_shape, AnyInput(), AnyInput()])
 
             def callback(m: Matcher) -> bool:
+                # TODO: Check that seq has axis that really takes sequence len but not any other dimension -- use symbolics or look at the constant input
+                gather = m.get_match_root()
+                target_type = gather.get_output_element_type(0)
+                if prev_max_seq_len.get_output_element_type(0) != target_type:
+                    print(f'Converting {prev_max_seq_len.get_output_element_type(0)} of max_context_len to {target_type}')
+                    replacement = opset13.convert(prev_max_seq_len, target_type)
+                else:
+                    replacement = prev_max_seq_len
+                replace_node(gather, replacement)
+                print("DETECTED PATTERN PrevSequenceLengthPattern, CONNECTED TO A DEDICATED PARAMETER")
+                return True
+
+            self.register_matcher(Matcher(seq, "PrevSequenceLengthPattern"), callback)
+
+    class TotalSequenceLengthPattern(MatcherPass):
+        def __init__(self):
+            MatcherPass.__init__(self)
+            self.model_changed = False
+
+            kv_past = WrapType("opset13.ReadValue", AnyInput())
+            kv_gather = WrapType("opset13.Gather", [kv_past, AnyInput(), AnyInput()])
+            kv_current = AnyInput()
+            kv_concat = WrapType("opset13.Concat", [kv_gather, kv_current])
+            kv_shape = WrapType("opset13.ShapeOf", [kv_concat])
+            seq = WrapType("opset13.Gather", [kv_shape, AnyInput(), AnyInput()])
+
+            def callback(m: Matcher) -> bool:
+                # TODO: Check that seq has axis that really takes sequence len but not any other dimension -- use symbolic infra or look at the constant input
                 gather = m.get_match_root()
                 target_type = gather.get_output_element_type(0)
                 if max_context_len.get_output_element_type(0) != target_type:
-                    print(f'Converting {max_context_len.get_output_element_type(0)} of max_context_len to {target_type}')
+                    print(f'Converting {max_context_len.get_output_element_type(0)} of total_seq_len to {target_type}')
                     replacement = opset13.convert(max_context_len, target_type)
                 else:
                     replacement = max_context_len
                 replace_node(gather, replacement)
-                print("DETECTED PATTERN FOR max_sequence_length, CONNECTED TO A DEDICATED PARAMETER")
+                print("DETECTED PATTERN TotalSequenceLengthPattern, CONNECTED TO A DEDICATED PARAMETER")
                 return True
 
-            self.register_matcher(Matcher(seq, "MaxSequenceLengthPattern"), callback)
+            self.register_matcher(Matcher(seq, "TotalSequenceLengthPattern"), callback)
 
     # TODO: Instead of using the following transformation that matches quite a specific place in a model graph in case when position_ids parameter is missing,
     #       consider replacing always existing attention_mask parameter with a sub-graph using a new slot_mapping parameter.
@@ -224,9 +327,9 @@ def patch_stateful_model(
             input_ids = AnyInput()
             input_embed = WrapType("opset13.Gather", [AnyInput(), input_ids, AnyInput()])
 
-            position_ids = AnyInput()
+            position_ids_pattern = AnyInput()
             offset = WrapType('opset13.Constant')
-            add_offset = WrapType('opset13.Add', [position_ids, offset])
+            add_offset = WrapType('opset13.Add', [position_ids_pattern, offset])
             convert = WrapType('opset13.Convert', [add_offset])
             position_embed = WrapType("opset13.Gather", [AnyInput(), convert, AnyInput()])
 
@@ -234,28 +337,19 @@ def patch_stateful_model(
 
             def callback(m: Matcher) -> bool:
                 mapping = m.get_pattern_value_map()
-                if not position_ids_parameter:
-                    position_ids_parameter.append(opset13.parameter(shape=[-1, -1], dtype=np.int64, name="position_ids"))
-                    print('CREATED A NEW position_ids PARAMETER')
-                replace_node(mapping[position_ids].get_node(), position_ids_parameter[0])
-                position_ids_parameter[0].get_output_tensor(0).set_names({'position_ids'})
+                replace_node(mapping[position_ids_pattern].get_node(), position_ids.get_node())
                 print('APPLIED position_ids PARAMETER INSTEAD OF attention_mask-BASED SUB-GRAPH')
                 return True
 
-            self.register_matcher(Matcher(add, "InputAndPoistionIDsAdd"), callback)
+            self.register_matcher(Matcher(add, "PositionIDsReplacer"), callback)
 
     m = Manager()
     m.set_per_pass_validation(False)
     m.register_pass(StateManagementPattern())
-    m.register_pass(MaxSequenceLengthPattern())
+    m.register_pass(PrevSequenceLengthPattern())
+    m.register_pass(TotalSequenceLengthPattern())
 
-    def has_parameter(model, name):
-        return name in sum([list(t.get_names()) for t in model.inputs], [])
-
-    if has_parameter(model, 'position_ids'):
-        position_ids_parameter.append(model.input('position_ids').get_node())
-    else:
-        m.register_pass(PositionIDsReplacer())
+    m.register_pass(PositionIDsReplacer())
 
     m.run_passes(model)
 
@@ -267,12 +361,14 @@ def patch_stateful_model(
     # print('sinks_to_remove:', assignes_to_remove)
     for parameter in parameters_to_remove:
         model.remove_parameter(parameter)
-    for sink in assignes_to_remove:
+    # Remove all Assigns aggressively, the path from the kv-cache concat to Assign can be complicated,
+    # but there is no reason to track it and reject part of the Assigns, because the model will remain
+    # in incorrect form anyway.
+    sinks = model.get_sinks()
+    for sink in sinks:
         model.remove_sink(sink)
     for result in results_to_remove:
         model.remove_result(result)
-    if not has_parameter(model, 'position_ids'):
-        model.add_parameters(position_ids_parameter)
     model.add_parameters(kv_parameters)
     model.add_parameters(model_remaining_params)
     print('PARAMETERS ARE REORGANIZED, THE STATE (IF EXISTS) IS REMOVED')
@@ -437,6 +533,10 @@ def ov_sample(
 
 
 def require_model_export(model_id, revision=None, subfolder=None):
+    # Stored IR may not be suitable for vLLM purposes (too old, not stateful, not compressed etc.)
+    # This is an option to override IR usage logic and alway do model conversion.
+    if os.environ.get('VLLM_OPENVINO_OPTIMUM_FORCE_CONVERSION', '0') == '1':
+        return True
     model_dir = Path(model_id)
     if subfolder is not None:
         model_dir = model_dir / subfolder
@@ -448,7 +548,7 @@ def require_model_export(model_id, revision=None, subfolder=None):
         model_info = hf_api.model_info(model_id, revision=revision or "main")
         normalized_subfolder = None if subfolder is None else Path(subfolder).as_posix()
         model_files = [file.rfilename for file in model_info.siblings if normalized_subfolder is None or file.rfilename.startswith(normalized_subfolder)]
-        ov_model_path = "openvino_model.xml" if subfolder is None else f"{normalized_subfolder}/openvino_model.xml"
+        ov_model_path = "openvino_model.xml" if normalized_subfolder is None else f"{normalized_subfolder}/openvino_model.xml"
         return not ov_model_path in model_files or not ov_model_path.replace(".xml", ".bin") in model_files
     except Exception:
          return True
@@ -490,6 +590,12 @@ def get_model(model_config: ModelConfig,
             pt_model.ov_node_factory = NodeFactory()
             pt_model.ov_node_factory.add_extension('libuser_ov_extensions.so')
         patch_stateful_model(pt_model.model, pt_model.ov_node_factory, kv_cache_dtype)
+
+        # For deployment outside vLLM
+        model_file_name = os.environ.get('VLLM_OPENVINO_EXPORTED_IR_NAME', '')
+        if model_file_name:
+            ov.save_model(pt_model.model, model_file_name)
+
         core = ov.Core()
         ov_compiled = core.compile_model(pt_model.model, "CPU")
         pt_model._ov_request = ov_compiled.create_infer_request()

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -135,6 +135,8 @@ def is_openvino() -> bool:
     return is_openvino_available
 
 def is_openvino_optimum_intel() -> bool:
+    if os.environ.get('VLLM_OPENVINO_OPTIMUM', '1') == '0':
+        return False
     is_optimum_intel_available = is_openvino()
     try:
         import optimum.intel


### PR DESCRIPTION
This is a cumulative PR with a set of changes.

Main changes:

- Support in the transformation for qwen-1, chatglm3, starcoder, bloom. Bloom still requires alibi support in PagedAttention CPU/GPU implementation (doesn't pass the accuracy check now).
- Results of starcoder2-7b now match vanilla HF.
- Fixed incorrect substitution of `max_context_len` (it was past kv state length, but it should be a total length: past + current).

Utilities:

- Load from IR if it exists in the directory with model id (checked for the hub-based location and local directory). A new env variable `VLLM_OPENVINO_OPTIMUM_FORCE_CONVERSION=1` overrides this new behavior and force model conversion. It consumes https://github.com/ilya-lavrenov/vllm/pull/17.
- A new env variable `VLLM_OPENVINO_EXPORTED_IR_NAME`=`file_name.xml` allows saving transformed model IR with PagedAttention to `file_name.xml` for deployment outside of vLLM.
- A new env variable `VLLM_OPENVINO_OPTIMUM=0` disables using optimum-intel-based path ignoring its availability and forcing vLLM based modeling.