### PR TITLE
Fix for multi-query attention

### DIFF
--- a/vllm/model_executor/openvino_model_loader.py
+++ b/vllm/model_executor/openvino_model_loader.py
@@ -61,7 +61,8 @@ def ov_wrapper(self, *args, **kwargs) -> torch.Tensor:
 def patch_stateful_model(
     model: ov.Model,
     factory,
-    kv_cache_dtype: Type):
+    kv_cache_dtype: Type,
+    is_cpu: bool):
     print('TRANSFORMING OPTIMUM-INTEL MODEL TO vLLM COMPATIBLE FORM')
     from openvino.runtime.passes import Manager, MatcherPass, WrapType, Matcher, AnyInput, Or
     from openvino.runtime import opset13
@@ -168,7 +169,7 @@ def patch_stateful_model(
                 real_q = mapping[q]
 
                 # takes option that has 4D instead of fine-grained Reshape analysis
-                # it is avoids complication in pattern, but we don't really have many options
+                # it avoids complication in the pattern, but we don't really have many options
                 def take_4d(option1, option2, option3):
                     if option1 in mapping and mapping[option1].get_partial_shape().rank.get_length() == 4:
                         return mapping[option1]
@@ -179,7 +180,10 @@ def patch_stateful_model(
 
                 real_k = take_4d(k_current, k_current_reshaped, k_current2)
                 real_v = take_4d(v_current, v_current_reshaped, v_current2)
-                k_parameter = opset13.parameter(shape=[-1, -1, -1, -1, -1], dtype=kv_cache_dtype)
+                if is_cpu:
+                    k_parameter = opset13.parameter(shape=[-1, -1, -1, -1], dtype=kv_cache_dtype)
+                else:
+                    k_parameter = opset13.parameter(shape=[-1, -1, -1, -1, -1], dtype=kv_cache_dtype)
                 v_parameter = opset13.parameter(shape=[-1, -1, -1, -1], dtype=kv_cache_dtype)
                 kv_parameters.append(k_parameter)
                 kv_parameters.append(v_parameter)
@@ -376,7 +380,8 @@ def patch_stateful_model(
 def _patch_model_with_openvino(
         pt_model: torch.nn.Module,
         model_config: ModelConfig,
-        kv_cache_dtype: Type):
+        kv_cache_dtype: Type,
+        is_cpu: bool):
     print(' ============= PATCHING MODEL =============')
     from vllm.model_executor.layers.attention.attention import Attention
     from openvino.frontend.pytorch import ModuleExtension
@@ -429,8 +434,12 @@ def _patch_model_with_openvino(
     start_loc = torch.ones(max_batch_size, dtype=torch.long)
     block_tables = torch.ones((max_batch_size, max_num_blocks), dtype=torch.int32)
 
-    kv_cache = [(torch.ones((_EXAMPLE_NUM_BLOCKS, num_kv_heads, head_size // _X, _EXAMPLE_BLOCK_SIZE, _X), dtype=kv_cache_dtype),
-                 torch.ones((_EXAMPLE_NUM_BLOCKS, num_kv_heads, head_size, _EXAMPLE_BLOCK_SIZE), dtype=kv_cache_dtype))] * num_hidden_layers
+    if is_cpu:
+        kv_cache = [(torch.ones((_EXAMPLE_NUM_BLOCKS, num_kv_heads, _EXAMPLE_BLOCK_SIZE, head_size), dtype=kv_cache_dtype),
+                    torch.ones((_EXAMPLE_NUM_BLOCKS, num_kv_heads, _EXAMPLE_BLOCK_SIZE, head_size), dtype=kv_cache_dtype))] * num_hidden_layers
+    else:
+        kv_cache = [(torch.ones((_EXAMPLE_NUM_BLOCKS, num_kv_heads, head_size // _X, _EXAMPLE_BLOCK_SIZE, _X), dtype=kv_cache_dtype),
+                    torch.ones((_EXAMPLE_NUM_BLOCKS, num_kv_heads, head_size, _EXAMPLE_BLOCK_SIZE), dtype=kv_cache_dtype))] * num_hidden_layers
 
     input_meta = {
         "is_prompt": torch.tensor(False),
@@ -589,7 +598,7 @@ def get_model(model_config: ModelConfig,
             # Keep factory to destroy it in a particular moment when all other objects referencing custom nodes are destoyed
             pt_model.ov_node_factory = NodeFactory()
             pt_model.ov_node_factory.add_extension('libuser_ov_extensions.so')
-        patch_stateful_model(pt_model.model, pt_model.ov_node_factory, kv_cache_dtype)
+        patch_stateful_model(pt_model.model, pt_model.ov_node_factory, kv_cache_dtype, device_config.device.type == "cpu")
 
         # For deployment outside vLLM
         model_file_name = os.environ.get('VLLM_OPENVINO_EXPORTED_IR_NAME', '')
@@ -609,6 +618,6 @@ def get_model(model_config: ModelConfig,
     else:
         from vllm.model_executor.model_loader import get_model
         pt_model = get_model(model_config, device_config, **kwargs)
-        _patch_model_with_openvino(pt_model, model_config, kv_cache_dtype)
+        _patch_model_with_openvino(pt_model, model_config, kv_cache_dtype, device_config.device.type == "cpu")
 
     return pt_model

--- a/vllm/model_executor/openvino_model_loader.py
+++ b/vllm/model_executor/openvino_model_loader.py
@@ -177,8 +177,8 @@ def patch_stateful_model(
                     else:
                         return mapping[option3]
 
-                real_k = take_4d(k_current, k_current2, k_current_reshaped)
-                real_v = take_4d(v_current, v_current2, v_current_reshaped)
+                real_k = take_4d(k_current, k_current_reshaped, k_current2)
+                real_v = take_4d(v_current, v_current_reshaped, v_current2)
                 k_parameter = opset13.parameter(shape=[-1, -1, -1, -1, -1], dtype=kv_cache_dtype)
                 v_parameter = opset13.parameter(shape=[-1, -1, -1, -1], dtype=kv_cache_dtype)
                 kv_parameters.append(k_parameter)


### PR DESCRIPTION
Fixes the case of 1 kv head attention where not anticipated optimization happens that turns Transpose to Reshape. It confuses a new, more sophisticated pattern logic, that expects another 4D Reshape at that place and uses the wrong point in the graph to capture the current K or V. Reproduced with gemma-2b.