### PR TITLE
Add bitsandbytes to requirements and use fixed vllm version in the client

### DIFF
--- a/requirements-openvino.txt
+++ b/requirements-openvino.txt
@@ -7,7 +7,7 @@ pydantic >= 2.0  # Required for OpenAI server.
 prometheus_client >= 0.18.0
 torch >= 2.1.2
 transformers >= 4.38.0  # Required for Gemma.
-openvino==2024.1.0
+openvino>=2024.1.0
 optimum-intel[openvino,nncf] @ git+https://github.com/huggingface/optimum-intel.git@d2f9fdb5107d5df1887f8a4bd138682b73e9f79c
 outlines >= 0.0.27
 einops

--- a/requirements-openvino.txt
+++ b/requirements-openvino.txt
@@ -15,3 +15,4 @@ ai2-olmo # hf_olmo
 tiktoken
 # flash-attn # // failed to install
 transformers_stream_generator
+bitsandbytes

--- a/use_with_openvino.md
+++ b/use_with_openvino.md
@@ -41,7 +41,7 @@ cd benchmarks
 wget https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json
 
 # Install PyPI dependencies (vLLM and aiohttp seem to be enough)
-pip3 install vllm aiohttp
+pip3 install vllm==0.3.3 aiohttp
 
 # Launch benchmark script
 python3 benchmark_serving.py --backend openai --endpoint /v1/completions --port 8000 --model meta-llama/Llama-2-7b-hf --dataset ShareGPT_V3_unfiltered_cleaned_split.json


### PR DESCRIPTION
- bitsandbytes package is required by baichuan model
- there were errors when running benchmark sample with latest vllm, using fixed version gives more stability 