### PR TITLE
Use upgraded PA transformation from C++

### DIFF
--- a/vllm/model_executor/openvino_model_loader.py
+++ b/vllm/model_executor/openvino_model_loader.py
@@ -70,6 +70,12 @@ def patch_stateful_model(
     model: ov.Model,
     kv_cache_dtype: Type,
     is_cpu: bool):
+    if False:
+        from openvino._offline_transformations import paged_attention_transformation
+        paged_attention_transformation(model)
+        # TODO: Apply shapes depending on is_cpu and kv cache type here.
+        # TODO: Consider eliminating those adjustments later
+        return
     print('TRANSFORMING OPTIMUM-INTEL MODEL TO vLLM COMPATIBLE FORM')
     from openvino.runtime.passes import Manager, MatcherPass, WrapType, Matcher, AnyInput, Or
     from openvino.runtime import opset13


### PR DESCRIPTION
Upgraded PA transformation flow to split a single transformation into two parts: HW-agnostic and HW-dependent. HW-agnostic transformation generates simplified kv-cache shapes that do not have blocking. Upgraded version of the transformation deduce number of kv heads and head_size from the model and can work without optimum dependency. HW-dependent part recombines dimensions derived by HW-agnostic part to introduce blocking and set layout and element type according to HW plugins preferences.

Switched to C++ part of HW-agnostic transformation implemented here: https://github.com/openvinotoolkit/openvino/pull/24400.

Kept Python version of transformation for fast patching. When validation was passed for majority of models and the transformation is stabilized, we are going to remove the python version.